### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(ami)* OriginateResponse event no longer swallowed as action response
 
 
+### Other
+- release ([#11](https://github.com/deadcode-walker/asterisk-rs/pull/11))
+
+
+### Testing
+- restructure test architecture + add massive coverage
+- add 120 unit tests across all crates (Wave 1)
+
+
+### Fixed
+- *(ami)* OriginateResponse event no longer swallowed as action response
+
+
+### Other
+- release ([#11](https://github.com/deadcode-walker/asterisk-rs/pull/11))
+
+
+### Fixed
+- *(ami)* OriginateResponse event no longer swallowed as action response
+
+
 ### Testing
 - restructure test architecture + add massive coverage
 - add 120 unit tests across all crates (Wave 1)


### PR DESCRIPTION



## 🤖 New release

* `asterisk-rs-ami`: 0.4.1 -> 0.4.2
* `asterisk-rs`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `asterisk-rs-ami`

<blockquote>


### Fixed
- *(ami)* OriginateResponse event no longer swallowed as action response


### Other
- release ([#11](https://github.com/deadcode-walker/asterisk-rs/pull/11))
</blockquote>

## `asterisk-rs`

<blockquote>


### Fixed
- *(ami)* OriginateResponse event no longer swallowed as action response


### Other
- release ([#11](https://github.com/deadcode-walker/asterisk-rs/pull/11))


### Testing
- restructure test architecture + add massive coverage
- add 120 unit tests across all crates (Wave 1)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).