### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,106 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Other
+- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))
+- updated crate description to async
+
+
+### Testing
+- restructure test architecture + add massive coverage
+- add 120 unit tests across all crates (Wave 1)
+
+
+### Added
+- add #[must_use] to builder types and doc comments to public items
+
+
+### Documentation
+- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))
+
+
+### Fixed
+- resource management, validation, and correctness improvements
+- *(protocol)* corrected AMI framing, reconnect, AGI safety, ARI error handling
+- *(security)* rejected protocol injection and credential leaks
+
+
+### Other
+- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))
+
+
+### Added
+- add #[must_use] to builder types and doc comments to public items
+
+
+### Documentation
+- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))
+
+
+### Fixed
+- credential zeroize, ChanVariable propagation, test rigor, endpos parsing
+- resource management, validation, and correctness improvements
+- *(protocol)* corrected AMI framing, reconnect, AGI safety, ARI error handling
+- *(security)* rejected protocol injection and credential leaks
+
+
+### Other
+- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))
+
+
+### Documentation
+- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))
+
+
+### Fixed
+- credential zeroize, ChanVariable propagation, test rigor, endpos parsing
+- resource management, validation, and correctness improvements
+- *(protocol)* corrected AMI framing, reconnect, AGI safety, ARI error handling
+- *(security)* rejected protocol injection and credential leaks
+
+
+### Other
+- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))
+
+
+### Testing
+- restructure test architecture + add massive coverage
+- add 120 unit tests across all crates (Wave 1)
+
+
+### Documentation
+- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))
+
+
+### Fixed
+- credential zeroize, ChanVariable propagation, test rigor, endpos parsing
+- resource management, validation, and correctness improvements
+
+
+### Other
+- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))
+
+
+### Testing
+- restructure test architecture + add massive coverage
+- add 120 unit tests across all crates (Wave 1)
+
+
+### Added
+- add #[must_use] to builder types and doc comments to public items
+
+
+### Documentation
+- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))
+
+
+### Fixed
+- resource management, validation, and correctness improvements
+- credential zeroize, ChanVariable propagation, test rigor, endpos parsing
+- *(protocol)* corrected AMI framing, reconnect, AGI safety, ARI error handling
+- *(security)* rejected protocol injection and credential leaks
+
+
+### Other
 - updated crate description to async
 
 


### PR DESCRIPTION



## 🤖 New release

* `asterisk-rs-core`: 0.2.1 -> 0.3.0
* `asterisk-rs-agi`: 0.2.1 -> 0.2.2
* `asterisk-rs-ami`: 0.4.2 -> 0.5.0
* `asterisk-rs-ari`: 0.4.0 -> 0.4.1
* `asterisk-rs`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `asterisk-rs-core`

<blockquote>


### Documentation
- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))


### Fixed
- credential zeroize, ChanVariable propagation, test rigor, endpos parsing
- resource management, validation, and correctness improvements


### Other
- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))


### Testing
- restructure test architecture + add massive coverage
- add 120 unit tests across all crates (Wave 1)
</blockquote>

## `asterisk-rs-agi`

<blockquote>


### Documentation
- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))


### Fixed
- credential zeroize, ChanVariable propagation, test rigor, endpos parsing
- resource management, validation, and correctness improvements
- *(protocol)* corrected AMI framing, reconnect, AGI safety, ARI error handling
- *(security)* rejected protocol injection and credential leaks


### Other
- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))


### Testing
- restructure test architecture + add massive coverage
- add 120 unit tests across all crates (Wave 1)
</blockquote>

## `asterisk-rs-ami`

<blockquote>


### Added
- add #[must_use] to builder types and doc comments to public items


### Documentation
- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))


### Fixed
- credential zeroize, ChanVariable propagation, test rigor, endpos parsing
- resource management, validation, and correctness improvements
- *(protocol)* corrected AMI framing, reconnect, AGI safety, ARI error handling
- *(security)* rejected protocol injection and credential leaks


### Other
- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))
</blockquote>

## `asterisk-rs-ari`

<blockquote>


### Added
- add #[must_use] to builder types and doc comments to public items


### Documentation
- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))


### Fixed
- resource management, validation, and correctness improvements
- *(protocol)* corrected AMI framing, reconnect, AGI safety, ARI error handling
- *(security)* rejected protocol injection and credential leaks


### Other
- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))
</blockquote>

## `asterisk-rs`

<blockquote>


### Added
- add #[must_use] to builder types and doc comments to public items


### Documentation
- added examples and improved READMEs ([#15](https://github.com/deadcode-walker/asterisk-rs/pull/15))


### Fixed
- resource management, validation, and correctness improvements
- credential zeroize, ChanVariable propagation, test rigor, endpos parsing
- *(protocol)* corrected AMI framing, reconnect, AGI safety, ARI error handling
- *(security)* rejected protocol injection and credential leaks


### Other
- release ([#16](https://github.com/deadcode-walker/asterisk-rs/pull/16))
- updated crate description to async


### Testing
- restructure test architecture + add massive coverage
- add 120 unit tests across all crates (Wave 1)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).